### PR TITLE
Correzioni di sicurezza Dependabot 2

### DIFF
--- a/ServerService/MultiP-server/yarn.lock
+++ b/ServerService/MultiP-server/yarn.lock
@@ -831,7 +831,7 @@ axios@^0.28.0:
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.28.0.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
   integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
   dependencies:
-    follow-redirects "1.5.10"
+    follow-redirects "1.15.6"
     is-buffer "^2.0.2"
 
 balanced-match@^1.0.0:
@@ -1767,9 +1767,9 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+follow-redirects@1.15.6:
+  version "1.15.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
   integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
   dependencies:
     debug "=3.1.0"

--- a/ServerService/MultiP-server/yarn.lock
+++ b/ServerService/MultiP-server/yarn.lock
@@ -2611,7 +2611,7 @@ meow@^5.0.0:
     normalize-package-data "^2.3.4"
     read-pkg-up "^3.0.0"
     redent "^2.0.0"
-    trim-newlines "^2.0.0"
+    trim-newlines "^3.0.1"
     yargs-parser "^10.0.0"
 
 meow@^6.0.0:
@@ -2627,7 +2627,7 @@ meow@^6.0.0:
     normalize-package-data "^2.5.0"
     read-pkg-up "^7.0.1"
     redent "^3.0.0"
-    trim-newlines "^3.0.0"
+    trim-newlines "^3.0.1"
     type-fest "^0.13.1"
     yargs-parser "^18.1.3"
 
@@ -3735,12 +3735,7 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
-trim-newlines@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
-  integrity sha512-MTBWv3jhVjTU7XR3IQHllbiJs8sc75a80OEhB6or/q7pLTWgQ0bMGQXXYQSrSuXe6WiKWDZ5txXY5P59a/coVA==
-
-trim-newlines@^3.0.0:
+trim-newlines@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
   integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==

--- a/ServerService/MultiP-server/yarn.lock
+++ b/ServerService/MultiP-server/yarn.lock
@@ -826,9 +826,9 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^0.18.0:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
+axios@^0.21.2:
+  version "0.21.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
   integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
   dependencies:
     follow-redirects "1.5.10"
@@ -3750,7 +3750,7 @@ ts@^0.2.2:
   resolved "https://registry.yarnpkg.com/ts/-/ts-0.2.2.tgz#62124118ef6212297ab7e959906b324dabf6832d"
   integrity sha512-cftcjXvrxBi6TJxwXjKZXm9g8eNClLQuEN+Yt90o0baDCpRDCCYsDEz3Uhpc5D2Wx1IZE1G1B4M8GY3OLsczzQ==
   dependencies:
-    axios "^0.18.0"
+    axios "^0.21.2"
     figures "^2.0.0"
     find-package-json "^1.1.0"
     glob "^7.1.3"

--- a/ServerService/MultiP-server/yarn.lock
+++ b/ServerService/MultiP-server/yarn.lock
@@ -826,9 +826,9 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^0.21.2:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
+axios@^0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.28.0.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
   integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
   dependencies:
     follow-redirects "1.5.10"
@@ -3750,7 +3750,7 @@ ts@^0.2.2:
   resolved "https://registry.yarnpkg.com/ts/-/ts-0.2.2.tgz#62124118ef6212297ab7e959906b324dabf6832d"
   integrity sha512-cftcjXvrxBi6TJxwXjKZXm9g8eNClLQuEN+Yt90o0baDCpRDCCYsDEz3Uhpc5D2Wx1IZE1G1B4M8GY3OLsczzQ==
   dependencies:
-    axios "^0.21.2"
+    axios "^0.28.0"
     figures "^2.0.0"
     find-package-json "^1.1.0"
     glob "^7.1.3"

--- a/ServerService/MultiP-server/yarn.lock
+++ b/ServerService/MultiP-server/yarn.lock
@@ -2612,7 +2612,7 @@ meow@^5.0.0:
     read-pkg-up "^3.0.0"
     redent "^2.0.0"
     trim-newlines "^3.0.1"
-    yargs-parser "^10.0.0"
+    yargs-parser "^13.1.2"
 
 meow@^6.0.0:
   version "6.1.1"
@@ -2629,7 +2629,7 @@ meow@^6.0.0:
     redent "^3.0.0"
     trim-newlines "^3.0.1"
     type-fest "^0.13.1"
-    yargs-parser "^18.1.3"
+    yargs-parser "^13.1.2"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -2776,7 +2776,7 @@ mocha@^10.2.0:
     supports-color "8.1.1"
     workerpool "6.2.1"
     yargs "16.2.0"
-    yargs-parser "20.2.4"
+    yargs-parser "13.1.2"
     yargs-unparser "2.0.0"
 
 ms@2.0.0:
@@ -4064,34 +4064,34 @@ yallist@^2.1.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
   integrity sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
 
-yargs-parser@20.2.4:
-  version "20.2.4"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
+yargs-parser@13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#b42890f14566796f85ae8e3a25290d205f154a54"
   integrity sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
 
-yargs-parser@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
   integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
   dependencies:
     camelcase "^4.1.0"
 
-yargs-parser@^18.1.2, yargs-parser@^18.1.3:
-  version "18.1.3"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+yargs-parser@^13.1.2, yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^20.2.2:
-  version "20.2.9"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
 
-yargs-parser@^21.1.1:
-  version "21.1.1"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs-unparser@2.0.0:
@@ -4115,7 +4115,7 @@ yargs@16.2.0:
     require-directory "^2.1.1"
     string-width "^4.2.0"
     y18n "^5.0.5"
-    yargs-parser "^20.2.2"
+    yargs-parser "^13.1.2"
 
 yargs@^15.1.0:
   version "15.4.1"
@@ -4132,7 +4132,7 @@ yargs@^15.1.0:
     string-width "^4.2.0"
     which-module "^2.0.0"
     y18n "^4.0.0"
-    yargs-parser "^18.1.2"
+    yargs-parser "^13.1.2"
 
 yargs@^17.7.1:
   version "17.7.2"
@@ -4145,7 +4145,7 @@ yargs@^17.7.1:
     require-directory "^2.1.1"
     string-width "^4.2.3"
     y18n "^5.0.5"
-    yargs-parser "^21.1.1"
+    yargs-parser "^13.1.2"
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
### Causa
Causati da commit: [7420512](https://github.com/Croc-Prog-github/The-Bocchette-2/commit/742051280e9f2d3493f709b141aa6487778ab9cf)

### Coinvolgimenti
Avvisi di sicurezza coinvolti:
- Gravità moderata:
  - 10

### Risolti
- Gravità moderata:
  - 10