### PR TITLE
Potential fix for code scanning alert no. 5021: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -1,4 +1,6 @@
 name: NodeJS with Webpack
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Croc-Prog-github/The-Bocchette-2/security/code-scanning/5021](https://github.com/Croc-Prog-github/The-Bocchette-2/security/code-scanning/5021)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify `contents: read`, which is sufficient for the current workflow since it only checks out the repository and builds the project. No write permissions are required.

The `permissions` block will be added immediately after the `name` field at the top of the file to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
