### PR TITLE
Potential fix for code scanning alert no. 5020: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,4 +1,6 @@
 name: The-Bocchette-2 Actions
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Croc-Prog-github/The-Bocchette-2/security/code-scanning/5020](https://github.com/Croc-Prog-github/The-Bocchette-2/security/code-scanning/5020)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only needs to read the repository contents (e.g., to check out the code and install dependencies), we will set `contents: read`. This ensures that the workflow does not have unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
