### PR TITLE
Potential fix for code scanning alert no. 5019: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow that is manually triggered
 
 name: Manual workflow
+permissions:
+  contents: read
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.


### PR DESCRIPTION
Potential fix for [https://github.com/Croc-Prog-github/The-Bocchette-2/security/code-scanning/5019](https://github.com/Croc-Prog-github/The-Bocchette-2/security/code-scanning/5019)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only echoes a greeting and does not interact with the repository or other GitHub features, the minimal permission `contents: read` is sufficient. This ensures that the workflow adheres to the principle of least privilege.

The `permissions` block will be added immediately after the `name` field (line 3) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
